### PR TITLE
"so, exactly" => "[It]'s not exactly"

### DIFF
--- a/_posts/2018-09-05-117.md
+++ b/_posts/2018-09-05-117.md
@@ -45,7 +45,7 @@ Ex-except Elias, obviously, that's not - I mean - I've listened to the tapes. I'
 
 And... aside from some, uh, uh, office gossip which I, I'm not sure is necessary or, uh, conducive to a workplace that... hey, it, it, it's natural it's, it's normal. There's, there's no there's no sinister hidden motives or... it's fine. It, it's fine.
 
-So, I guess... sometime in the next few days, I go on a commando mission to blow up a wax museum. So, exactly what I was expecting from an archiving job. I do worry about Martin and Melanie, and leaving them behind with... I suppose that's part of trusting someone isn't it? Letting them help how they can.
+So, I guess... sometime in the next few days, I go on a commando mission to blow up a wax museum. 's not exactly what I was expecting from an archiving job. I do worry about Martin and Melanie, and leaving them behind with... I suppose that's part of trusting someone isn't it? Letting them help how they can.
 
 Oh, yeah, I found something on the other body the circus stole _[laugh],_ this "George Icarus." Apparently he was interred earlier this year. I did a bit of _[laugh]_ digging, and it looks like the plot and the headstone were paid for by... the Magnus Institute! And I can think of only one man who died within the last few months who the Institute would want buried under a pseudonym. Only one who spent his life so close to fear that his skin would be useful in a ritual like this. I don't know what to actually *do* with this information, but... god. Jurgen Leitner. I just can't be rid of him.
 


### PR DESCRIPTION
because currently the transcript says the opposite of the actual meaning