### PR TITLE
Spelling correction of the quoted German in 127

### DIFF
--- a/_posts/2019-02-21-127.md
+++ b/_posts/2019-02-21-127.md
@@ -67,7 +67,7 @@ It was the face of Albrecht von Closen.
 
 In the light, his eyes met mine, and his mouth began to work furiously, repeating the same phrase over and over, increasing in volume until he was screaming it into my face: _(breath)_
 
-*"Leg sie ala zurück. Leg sie ala zurück."*
+*"Leg sie alle zurück. Leg sie alle zurück."*
 
 Put them back. Put them *back*.
 


### PR DESCRIPTION
Hi, there seems to be a typo in this community transcript, the word used here should be "alle", which is German for "all".